### PR TITLE
Enable role dashboards and upsert ship positions

### DIFF
--- a/database.py
+++ b/database.py
@@ -411,6 +411,7 @@ class AISDatabase:
                 return []
 
             company_users = getattr(company, 'company_users', [])
+    @staticmethod
     def get_user_and_subordinates_tracked_ships(user_id):
         """Get tracked ships for a user and their subordinate users."""
         try:

--- a/database.py
+++ b/database.py
@@ -317,7 +317,7 @@ class AISDatabase:
                 notes=notes,
                 added_by=added_by,
                 added_date=datetime.now(UTC),
-                added_by_user=added_by_user_id
+                added_by_user_id=added_by_user_id
             )
 
             db.session.add(tracked_ship)
@@ -378,7 +378,7 @@ class AISDatabase:
     def get_user_tracked_ships(user_id):
         """Get tracked ships added by a specific user."""
         try:
-            tracked = TrackedShip.query.filter_by(added_by_user=user_id).join(Ship).all()
+            tracked = TrackedShip.query.filter_by(added_by_user_id=user_id).join(Ship).all()
             result = []
             for t in tracked:
                 t_dict = t.to_dict()
@@ -410,8 +410,9 @@ class AISDatabase:
             if not company:
                 return []
 
-            user_ids = [company.id] + [u.id for u in company.company_users]
-            tracked = TrackedShip.query.filter(TrackedShip.added_by_user.in_(user_ids)).join(Ship).all()
+            company_users = getattr(company, 'company_users', [])
+            user_ids = [company.id] + [u.id for u in company_users]
+            tracked = TrackedShip.query.filter(TrackedShip.added_by_user_id.in_(user_ids)).join(Ship).all()
             result = []
             for t in tracked:
                 t_dict = t.to_dict()

--- a/database.py
+++ b/database.py
@@ -134,7 +134,7 @@ class AISDatabase:
             )
 
             # Update existing position or create new
-            position = Position.query.get(mmsi)
+            position = Position.query.filter_by(mmsi=mmsi).first()
             if position:
                 position.latitude = position_data['latitude']
                 position.longitude = position_data['longitude']

--- a/database.py
+++ b/database.py
@@ -411,7 +411,15 @@ class AISDatabase:
                 return []
 
             company_users = getattr(company, 'company_users', [])
-            user_ids = [company.id] + [u.id for u in company_users]
+    def get_user_and_subordinates_tracked_ships(user_id):
+        """Get tracked ships for a user and their subordinate users."""
+        try:
+            user = User.query.get(user_id)
+            if not user:
+                return []
+
+            company_users = getattr(user, 'company_users', [])
+            user_ids = [user.id] + [u.id for u in company_users]
             tracked = TrackedShip.query.filter(TrackedShip.added_by_user_id.in_(user_ids)).join(Ship).all()
             result = []
             for t in tracked:

--- a/models/ship.py
+++ b/models/ship.py
@@ -66,3 +66,8 @@ class Ship(db.Model):
         # Import here to avoid circular imports
         from .tracked_ship import TrackedShip
         return TrackedShip.query.filter_by(mmsi=self.mmsi).first() is not None
+
+    @property
+    def latest_position(self):
+        """Return the ship's most recent position if available."""
+        return self.current_position

--- a/models/ship.py
+++ b/models/ship.py
@@ -71,6 +71,5 @@ class Ship(db.Model):
     def latest_position(self):
         """Return the ship's most recent position if available."""
         from .position import Position
-        """Return the ship's most recent position if available, using eager-loaded relationship."""
         # Assumes positions are ordered by timestamp descending due to relationship order_by
         return self.positions[0] if self.positions else None

--- a/models/ship.py
+++ b/models/ship.py
@@ -71,4 +71,6 @@ class Ship(db.Model):
     def latest_position(self):
         """Return the ship's most recent position if available."""
         from .position import Position
-        return Position.query.filter_by(mmsi=self.mmsi).order_by(Position.timestamp.desc()).first()
+        """Return the ship's most recent position if available, using eager-loaded relationship."""
+        # Assumes positions are ordered by timestamp descending due to relationship order_by
+        return self.positions[0] if self.positions else None

--- a/models/ship.py
+++ b/models/ship.py
@@ -70,4 +70,5 @@ class Ship(db.Model):
     @property
     def latest_position(self):
         """Return the ship's most recent position if available."""
-        return self.current_position
+        from .position import Position
+        return Position.query.filter_by(mmsi=self.mmsi).order_by(Position.timestamp.desc()).first()

--- a/models/tracked_ship.py
+++ b/models/tracked_ship.py
@@ -11,7 +11,7 @@ class TrackedShip(db.Model):
     name = db.Column(db.String(100))  # Custom name/alias for the tracked ship
     notes = db.Column(db.Text)  # Optional notes about why this ship is tracked
     added_date = db.Column(db.DateTime, default=datetime.now(timezone.utc), nullable=False)
-    added_by_user = db.Column(db.Integer, db.ForeignKey('users.id'))  # Link to user
+    added_by_user_id = db.Column(db.Integer, db.ForeignKey('users.id'))  # Link to user
     added_by = db.Column(db.String(100))  # Legacy field for backward compatibility
 
     # Relationships
@@ -31,6 +31,7 @@ class TrackedShip(db.Model):
             'notes': self.notes,
             'added_date': self.added_date.isoformat(),
             'added_by': self.added_by,
+            'added_by_user_id': self.added_by_user_id,
             'added_by_user': self.user.full_name if self.user else None,
             'ship_data': ship_data
         }

--- a/models/user.py
+++ b/models/user.py
@@ -72,7 +72,7 @@ class User(db.Model):
 
         if self.role == 'user':
             # Check current tracking count
-            current_count = TrackedShip.query.filter_by(added_by_user=self.id).count()
+            current_count = TrackedShip.query.filter_by(added_by_user_id=self.id).count()
             if current_count >= 5:
                 return False, "Free users limited to 5 tracked ships"
             return True, f"Can track {5 - current_count} more ships"

--- a/routes.py
+++ b/routes.py
@@ -178,7 +178,7 @@ def register_api_routes(app):
         if user_role != 'admin':
             from models import TrackedShip
             tracked_ship = TrackedShip.query.filter_by(mmsi=mmsi).first()
-            if tracked_ship and tracked_ship.added_by_user != user_id:
+            if tracked_ship and tracked_ship.added_by_user_id != user_id:
                 return jsonify({"success": False, "message": "You can only remove ships you added"}), 403
 
         result = AISDatabase.remove_tracked_ship(mmsi, removed_by_user_id=user_id)
@@ -205,7 +205,7 @@ def register_api_routes(app):
         if user_role != 'admin':
             from models import TrackedShip
             tracked_ship = TrackedShip.query.filter_by(mmsi=mmsi).first()
-            if tracked_ship and tracked_ship.added_by_user != user_id:
+            if tracked_ship and tracked_ship.added_by_user_id != user_id:
                 return jsonify({"success": False, "message": "You can only edit ships you added"}), 403
 
         name = data.get('name', '').strip() or None
@@ -233,7 +233,7 @@ def register_api_routes(app):
 
         # Check if ship is currently tracked by this user
         from models import TrackedShip
-        existing_track = TrackedShip.query.filter_by(mmsi=mmsi, added_by_user=user_id).first()
+        existing_track = TrackedShip.query.filter_by(mmsi=mmsi, added_by_user_id=user_id).first()
 
         if existing_track:
             # Remove from tracking
@@ -273,7 +273,7 @@ def register_api_routes(app):
         if not user:
             return jsonify({"success": False, "message": "User not found"}), 400
 
-        current_count = TrackedShip.query.filter_by(added_by_user=user_id).count()
+        current_count = TrackedShip.query.filter_by(added_by_user_id=user_id).count()
         can_track, message = user.can_track_ship()
         limit = user.get_tracking_limit()
 


### PR DESCRIPTION
## Summary
- Upsert ship positions instead of storing history
- Add latest_position property on ships and mark active tracked ships
- Provide user/company tracked ship helpers for role-based dashboards

## Testing
- `python -m py_compile app.py database.py models/ship.py models/position.py models/tracked_ship.py models/user.py auth.py dashboards.py routes.py services/ais_service.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6e8e8463c83259ddf0760f5ca6bc0